### PR TITLE
Parameter METATILESIZE made public

### DIFF
--- a/tiles_xyz/metadata.txt
+++ b/tiles_xyz/metadata.txt
@@ -11,7 +11,7 @@ name=Tiles XYZ
 qgisMinimumVersion=3.0
 qgisMaximumVersion=3.6.99
 description=Processing algorithm for generating raster tiles
-version=0.8
+version=0.8.1
 author=Lutra Consulting
 email=info@lutraconsulting.co.uk
 

--- a/tiles_xyz/tiles_xyz_algorithm.py
+++ b/tiles_xyz/tiles_xyz_algorithm.py
@@ -197,6 +197,7 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
         self.tile_format = self.formats[self.parameterAsEnum(parameters, self.TILE_FORMAT, context)]
         transparent = self.parameterAsBool(parameters, self.TRANSPARENT, context)
         quality = self.parameterAsInt(parameters, self.QUALITY, context)
+        self.metatilesize = self.parameterAsInt(parameters, self.METATILESIZE, context)
         try:
             tile_width = self.parameterAsInt(parameters, self.TILE_WIDTH, context)
             tile_height = self.parameterAsInt(parameters, self.TILE_HEIGHT, context)

--- a/tiles_xyz/tiles_xyz_algorithm.py
+++ b/tiles_xyz/tiles_xyz_algorithm.py
@@ -142,7 +142,8 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
     TILE_FORMAT = 'TILE_FORMAT'
     TRANSPARENT = 'TRANSPARENT'
     QUALITY = 'QUALITY'
-
+    METATILESIZE = 'METATILESIZE'
+    
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterExtent(self.EXTENT, self.tr('Extent')))
         self.addParameter(QgsProcessingParameterNumber(self.ZOOM_MIN,
@@ -173,6 +174,12 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
                                                        minValue=1,
                                                        maxValue=100,
                                                        defaultValue=75))
+        self.addParameter(QgsProcessingParameterNumber(self.METATILESIZE,
+                                                       self.tr('Metatile size'),
+                                                       minValue=1,
+                                                       maxValue=20,
+                                                       defaultValue=4))
+
 
     def prepareAlgorithm(self, parameters, context, feedback):
         project = context.project()
@@ -230,7 +237,7 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
         metatiles_by_zoom = {}
         metatiles_count = 0
         for zoom in range(self.min_zoom, self.max_zoom + 1):
-            metatiles = get_metatiles(self.wgs_extent, zoom, 4)
+            metatiles = get_metatiles(self.wgs_extent, zoom, self.metatilesize)
             metatiles_by_zoom[zoom] = metatiles
             metatiles_count += len(metatiles)
 


### PR DESCRIPTION
Changed to be able to establish the metatile size from the algorithm's request form. Changing the default value (4) for a bigger number (I suggest 16) seriously increases the algorithm speed at the expense of system memory. Arbitrary maximum of 20 for convenience.