### PR TITLE
Compatibility with future QGIS releases

### DIFF
--- a/tiles_xyz/metadata.txt
+++ b/tiles_xyz/metadata.txt
@@ -9,7 +9,7 @@
 [general]
 name=Tiles XYZ
 qgisMinimumVersion=3.0
-qgisMaximumVersion=3.6.99
+qgisMaximumVersion=3.99
 description=Processing algorithm for generating raster tiles
 version=0.8
 author=Lutra Consulting


### PR DESCRIPTION
The plugin is not possible to run on QGIS 3.8 due to version limit.
This pull-request change the limit to version 3.99!

![Skärmbild från 2019-06-22 22-53-31](https://user-images.githubusercontent.com/6375959/59968866-7df2fc80-9541-11e9-9b83-21ea3926ca28.png)
